### PR TITLE
fix: aws codepipeline issues.

### DIFF
--- a/backend/copilot/pipelines/clera-main/buildspec.yml
+++ b/backend/copilot/pipelines/clera-main/buildspec.yml
@@ -22,7 +22,7 @@ phases:
       - pipeline=$(cat $CODEBUILD_SRC_DIR/copilot/pipelines/clera-main/manifest.yml | ruby -ryaml -rjson -e 'puts JSON.pretty_generate(YAML.load(ARGF))')
       - echo "Pipeline JSON:"
       - echo "$pipeline"
-      - pl_envs=$(echo $pipeline | jq -r '.stages[].name')
+      - "pl_envs=$(echo $pipeline | jq -r '.stages[].name')"
       - echo "Environment names: $pl_envs"
       # Find all the local services in the workspace.
       - svc_ls_result=$(./copilot-linux svc ls --local --json)


### PR DESCRIPTION
attempt to resolve error with AWS code pipeline build:


[Container] 2025/04/21 21:48:28.940280 Phase context status code: YAML_FILE_ERROR Message: Expected Commands[9] to be of string type: found subkeys instead at line 26, value of the key tag on line 25 might be empty
9 |  

<br class="Apple-interchange-newline">

Solution:
- changes line 25 to be surrounded by quotes