### PR TITLE
Add supabase jwt header to news summary to pull portfolio data.

### DIFF
--- a/frontend-app/app/api/cron/generate-daily-summary/route.ts
+++ b/frontend-app/app/api/cron/generate-daily-summary/route.ts
@@ -382,9 +382,8 @@ export async function GET(request: Request) {
         }
 
         if (!portfolioString) {
-          // Fallback to major indices when user has no positions or fetch fails
-          const userPortfolio = [ { ticker: 'SPY', shares: 10 }, { ticker: 'DJI', shares: 10 } ];
-          portfolioString = userPortfolio.map(p => `${p.ticker} (${p.shares} shares)`).join(', ');
+          // Use sentinel value to trigger general market overview behavior in prompt
+          portfolioString = 'No positions found in portfolio.';
         }
         const currentDate = new Date().toISOString().split('T')[0];
 

--- a/frontend-app/app/api/cron/generate-daily-summary/route.ts
+++ b/frontend-app/app/api/cron/generate-daily-summary/route.ts
@@ -364,7 +364,14 @@ export async function GET(request: Request) {
           if (!backendUrl) {
             throw new Error('BACKEND_API_URL not configured');
           }
-          const targetUrl = `${backendUrl}/api/portfolio/${user.alpaca_account_id}/positions`;
+          // SECURITY: Never concatenate user-controlled IDs directly into URLs
+          // Validate and encode the alpaca_account_id before use
+          const rawAccountId = String(user.alpaca_account_id || '').trim();
+          if (!/^[-a-zA-Z0-9_]+$/.test(rawAccountId)) {
+            throw new Error('Invalid alpaca_account_id format');
+          }
+          const safeAccountId = encodeURIComponent(rawAccountId);
+          const targetUrl = `${backendUrl}/api/portfolio/${safeAccountId}/positions`;
           const headers: Record<string, string> = { 'Accept': 'application/json' };
           if (backendApiKey) headers['x-api-key'] = backendApiKey;
           const resp = await fetch(targetUrl, { method: 'GET', headers, cache: 'no-store' });

--- a/frontend-app/app/api/news/portfolio-summary/route.ts
+++ b/frontend-app/app/api/news/portfolio-summary/route.ts
@@ -348,7 +348,7 @@ async function generateSummaryForUser(userId: string, supabase: any, requestUrl:
       .single();
     if (onboardingError || !onboardingData?.alpaca_account_id) {
       console.error(`Error fetching Alpaca account ID for user ${userId}:`, onboardingError || 'No account ID found');
-      portfolioString = 'No account information available.';
+      portfolioString = 'No positions found in portfolio.';
       console.log(`User has no Alpaca account information - using general market overview.`);
     } else {
       const alpacaAccountId = onboardingData.alpaca_account_id;
@@ -367,7 +367,7 @@ async function generateSummaryForUser(userId: string, supabase: any, requestUrl:
       if (!positionsResponse.ok) {
         const errorText = await positionsResponse.text();
         console.error(`Error fetching portfolio positions for user ${userId} (Account ID: ${alpacaAccountId}). Status: ${positionsResponse.status}. Response: ${errorText}`);
-        portfolioString = 'Portfolio data temporarily unavailable.';
+        portfolioString = 'No positions found in portfolio.';
         console.log(`Portfolio fetch failed for user - using general market overview.`);
       } else {
         const positionsData: Array<{ symbol: string; qty: string; [key: string]: any }> = await positionsResponse.json();
@@ -382,7 +382,7 @@ async function generateSummaryForUser(userId: string, supabase: any, requestUrl:
     }
   } catch (error: any) {
     console.error(`Error fetching or processing portfolio data for user ${userId}:`, error);
-    portfolioString = 'Portfolio data unavailable due to system error.';
+    portfolioString = 'No positions found in portfolio.';
     console.log(`System error for user - using general market overview.`);
   }
   return await callPerplexityAndSaveResult(userId, portfolioString, userGoals, financialLiteracy, personalizationData, perplexity, supabase);

--- a/frontend-app/components/PostHogProvider.tsx
+++ b/frontend-app/components/PostHogProvider.tsx
@@ -50,18 +50,20 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
         }
         
         // Initialize PostHog only if not account closure
-        console.log('[PostHog] Initializing for regular user');
+        const isProd = process.env.NODE_ENV === 'production';
+        console.log('[PostHog] Initializing for regular user', { env: process.env.NODE_ENV });
         posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
           api_host: "/ingest",
           ui_host: "https://us.posthog.com",
           capture_pageview: false, // We capture pageviews manually
           capture_pageleave: true, // Enable pageleave capture
           // Reduce noise from dev refreshes and aborted requests being reported as exceptions
-          capture_exceptions: process.env.NODE_ENV === 'production',
-          enable_heatmaps: true,
+          capture_exceptions: isProd,
+          // rrweb-based features can interact poorly with DevTools in development; enable only in prod
+          enable_heatmaps: isProd,
           // Reduce noisy console/rrweb capture during sensitive auth/onboarding flows
           session_recording: {
-            enabled: true,
+            enabled: isProd,
             // Avoid rrweb console capture that can trigger regex overflow in some environments
             // PostHog forwards this to rrweb; unknown keys are ignored safely if unsupported
             captureConsoleLog: false as any,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes portfolio fetching in daily and news summaries by sending Supabase auth to the internal portfolio API so we use real Alpaca positions. Also limits PostHog tracking features to production to reduce dev noise.

- **Bug Fixes**
  - Forward Supabase auth cookies to the positions API in the news portfolio summary to authenticate requests and pull real holdings.
  - Cron daily summary now fetches positions from BACKEND_API_URL (uses x-api-key if set) and falls back to SPY/DJI when empty or on error.

- **Refactors**
  - PostHog init: enable exceptions, heatmaps, and session recording only in production; added simple env-aware logging.

<!-- End of auto-generated description by cubic. -->

